### PR TITLE
Allow Kim error_status to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 Changelog
 ========================
 
-v1.0.1
+v0.1.3
+-----------------------
+
+* Allow error_status to be overridden on Kim handler
+
+v0.1.1
 -----------------------
 
 * Fixed issue with Endpoint middleware. #11
 
-v1.0.0
+v0.1.0
 -----------------------
 
 Official release of Arrested.

--- a/arrested/__init__.py
+++ b/arrested/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 from .api import *
 from .endpoint import *

--- a/arrested/contrib/kim_arrested.py
+++ b/arrested/contrib/kim_arrested.py
@@ -23,6 +23,8 @@ class KimHandler(Handler):
             marshaling.
         :param many: Pass the many option to Kim when marshaling or serializing.
         :param raw: Pass the raw option to Kim when marshaling or serializing.
+        :param error_status: Set the HTTP status returned in the event of a
+            MappingInvalid on marshaling
         :returns: None
         """
         super(KimHandler, self).__init__(endpoint, *args, **params)
@@ -34,6 +36,7 @@ class KimHandler(Handler):
         self.raw = params.pop('raw', False)
         self.obj = params.pop('obj', None)
         self.partial = params.pop('partial', False)
+        self.error_status = params.pop('error_status', 422)
 
     @property
     def mapper(self):
@@ -120,10 +123,8 @@ class KimRequestHandler(KimHandler, RequestHandler):
                 )
     """
 
-    def handle(self, data, error_status=422, **kwargs):
+    def handle(self, data, **kwargs):
         """Run marshalling for the specified mapper_class.
-
-        * TODO(mike) Allows users to control the error reponse generated.
 
         Supports both .marshal and .many().marshal Kim interfaces.  Handles errors raised
         during marshalling and automatically returns a HTTP error response.
@@ -149,7 +150,7 @@ class KimRequestHandler(KimHandler, RequestHandler):
                 "message": "Invalid or incomplete data provided.",
                 "errors": e.errors
             }
-            self.endpoint.return_error(error_status, payload=payload)
+            self.endpoint.return_error(self.error_status, payload=payload)
 
 
 class KimEndpoint(Endpoint):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='arrested',
-    version='0.1.2',
+    version='0.1.3',
     author='Mikey Waites',
     author_email='mike@oldstlabs.com',
     url='https://github.com/mikeywaites/flask-arrested',

--- a/tests/test_contrib/test_kim.py
+++ b/tests/test_contrib/test_kim.py
@@ -64,12 +64,14 @@ def test_kim_handler_sets_opts():
         mapper_kwargs={'foo': 'bar'},
         role='test',
         many=True,
-        raw=True)
+        raw=True,
+        error_status=400)
     assert handler.mapper_class == MyMapper
     assert handler.mapper_kwargs == {'foo': 'bar'}
     assert handler.role == 'test'
     assert handler.many is True
     assert handler.raw is True
+    assert handler.error_status == 400
 
 
 def test_kim_handler_default_opts():
@@ -81,6 +83,7 @@ def test_kim_handler_default_opts():
     assert handler.role == '__default__'
     assert handler.many is False
     assert handler.raw is False
+    assert handler.error_status == 422
 
 
 def test_kim_response_handler_with_many():
@@ -187,10 +190,11 @@ def test_kim_request_handler_with_custom_error_status():
 
     data = [{'id': 1}, {'name': 'test 2'}]
     endpoint = CharactersEndpoint()
-    handler = KimRequestHandler(endpoint, mapper_class=MyMapper, many=True)
+    handler = KimRequestHandler(
+        endpoint, mapper_class=MyMapper, many=True, error_status=400)
 
     try:
-        handler.handle(data, error_status=400)
+        handler.handle(data)
         assert False, 'Did not raise UnprocessableEntity'
     except BadRequest as resp:
         assert resp.response.data == \


### PR DESCRIPTION
If a MappingInvalid is raised from Kim, previously the error status returned was (effectively) hard coded to 422. Now allow this to be passed in request handler params and overridden.